### PR TITLE
Describe Cargo test binary name (added hash)

### DIFF
--- a/_posts/2016-07-25-rust-code-coverage.md
+++ b/_posts/2016-07-25-rust-code-coverage.md
@@ -184,7 +184,7 @@ cargo test --no-run
 ```
 
 The compiled binaries are placed in `target/debug`. Cargo may create multiple
-test executables if you have multiple binaries.
+test executables if you have multiple binaries. Note that Cargo will postfix the test binary names with a hash, e.g. `<executable name>-012954d6a8535cff`, so make sure to pick the latest of these binaries for the next step.
 
 To run your tests and collect coverage, run kcov with the following command:
 


### PR DESCRIPTION
When following the steps of the post, I ran the wrong binary of my project.

My project is called `request_log_analyzer`. I assumed that `target/debug/<executable name>` means `target/debug/request_log_analyzer`. But this is not a test binary, rather the normal debug binary that is created by `cargo run`.

The test binary is the postfixed with a hash. This pull request adds this caveat to the description.

My versions:

```
$ cargo --version
cargo 0.15.0-nightly (298a012 2016-12-20)
$ rustc --version
rustc 1.14.0 (e8a012324 2016-12-16)
$ kcov --version
kcov 33
```